### PR TITLE
Handle missing tests folder in CI workflow

### DIFF
--- a/.github/workflows/PoShGallery-Publish.yml
+++ b/.github/workflows/PoShGallery-Publish.yml
@@ -46,10 +46,16 @@ jobs:
         if: matrix.shell == 'pwsh'
         shell: pwsh
         run: |
+          $testPath = Join-Path $PWD 'tests'
+          if (-not (Test-Path $testPath)) {
+            Write-Host "No tests directory found at $testPath. Skipping Pester run."
+            return
+          }
+
           $results = Join-Path $PWD "TestResults-pwsh.xml"
           $coverage = Join-Path $PWD "Coverage-pwsh.xml"
           Invoke-Pester `
-            -Path 'tests' `
+            -Path $testPath `
             -CI `
             -Output 'Detailed' `
             -OutputFormat NUnitXml `
@@ -61,10 +67,16 @@ jobs:
         if: matrix.shell == 'powershell'
         shell: powershell
         run: |
+          $testPath = Join-Path $PWD 'tests'
+          if (-not (Test-Path $testPath)) {
+            Write-Host "No tests directory found at $testPath. Skipping Pester run."
+            return
+          }
+
           $results = Join-Path $PWD "TestResults-powershell.xml"
           $coverage = Join-Path $PWD "Coverage-powershell.xml"
           Invoke-Pester `
-            -Path 'tests' `
+            -Path $testPath `
             -CI `
             -Output 'Detailed' `
             -OutputFormat NUnitXml `


### PR DESCRIPTION
## Summary
- skip Invoke-Pester when the tests directory is absent to avoid failing the release pipeline
- reuse the computed test path for the Invoke-Pester call in both matrix shells

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6915b1d2d57083278f0294dc6f677c60)